### PR TITLE
examples at bottom used wrong command name

### DIFF
--- a/README
+++ b/README
@@ -159,7 +159,7 @@ GENERATED RECORDS AND QUERYING
 EXAMPLES
        # Create records under amz.example.com, with instance names appearing
        # directly under .amz.example.com.
-       zone sync amz.example.com name.tag:.
+       zonify sync amz.example.com name.tag:.
        # Similar to above but stores changes to disk for later application.
-       zone ec2/r53 amz.example.com name.tag:. > changes.yaml
+       zonify ec2/r53 amz.example.com name.tag:. > changes.yaml
 


### PR DESCRIPTION
should be `zonify` instead of `zone`
