### PR TITLE
Do not consider EC2 instances in terminated state.

### DIFF
--- a/lib/zonify.rb
+++ b/lib/zonify.rb
@@ -92,18 +92,20 @@ class AWS
   end
   def instances
     ec2.servers.inject({}) do |acc, i|
-      dns = i.dns_name
-      # The default hostname for EC2 instances is derived from their internal
-      # DNS entry.
-      unless dns.nil? or dns.empty?
-        groups = (i.groups or [])
-        attrs = { :sg => groups,
-                  :tags => (i.tags or []),
-                  :dns => Zonify.dot_(dns).downcase }
-        if i.private_dns_name
-          attrs[:priv] = i.private_dns_name.split('.').first.downcase
+      if i.state != 'terminated'
+        dns = i.dns_name
+        # The default hostname for EC2 instances is derived from their internal
+        # DNS entry.
+        unless dns.nil? or dns.empty?
+          groups = (i.groups or [])
+          attrs = { :sg => groups,
+                    :tags => (i.tags or []),
+                    :dns => Zonify.dot_(dns).downcase }
+          if i.private_dns_name
+            attrs[:priv] = i.private_dns_name.split('.').first.downcase
+          end
+          acc[i.id] = attrs
         end
-        acc[i.id] = attrs
       end
       acc
     end


### PR DESCRIPTION
The terminated instances aren't coming back :)

We didn't add this new condition to the `unless` statement for two reasons:
1. Our version of `zonify` has a lot more going on in there besides `unless` :smirk_cat: 
2. It's hard to reason about `unless` statements that have lengthy boolean expressions in them without a couple of shots of scotch or whatnot.
