### PR TITLE
Fixed bug with ec2/r53 output

### DIFF
--- a/bin/zonify
+++ b/bin/zonify
@@ -214,7 +214,7 @@ def main
     _, old_records = aws.route53_zone(suffix)
     changes = Zonify.diff(mapped, old_records, (types or %w| CNAME SRV |))
     STDERR.puts(display(changes)) unless quiet
-    STDOUT.write(Zonify::YAML.trim_lines(YAML.dump(changes)))
+    STDOUT.write(YAML.dump(changes))
   when 'summarize'
     handle = ARGV[1] ? File.open(ARGV[1]) : STDIN
     changes = yaml_with_default(handle, [])
@@ -251,4 +251,3 @@ def main
 end
 
 main
-


### PR DESCRIPTION
It seemed that the ec2/r53 output was not correct - it was spitting out a nested YAML string inside of an array instead of the yaml format the other commands were spitting out.  
