### PR TITLE
Change TTL of generated records to 10 minutes

### DIFF
--- a/lib/zonify.rb
+++ b/lib/zonify.rb
@@ -172,8 +172,8 @@ def zone(hosts, elbs)
   host_records = hosts.map do |id,info|
     name = "#{id}.inst."
     priv = "#{info[:priv]}.priv."
-    [ Zonify::RR.cname(name, info[:dns], '86400'),
-      Zonify::RR.cname(priv, info[:dns], '86400'),
+    [ Zonify::RR.cname(name, info[:dns], '600'),
+      Zonify::RR.cname(priv, info[:dns], '600'),
       Zonify::RR.srv('inst.', name) ] +
     info[:tags].map do |tag|
       k, v = tag


### PR DESCRIPTION
Usually an IP for a node will not change, so a long TTL is desired. The exception is if we assign an elastic IP to a node. In these cases, however rare, we would like the change to propagate sooner than 24 hours.

/cc @pcarrier 
