### PR TITLE
Support updating initially empty R53 zones

### DIFF
--- a/lib/zonify.rb
+++ b/lib/zonify.rb
@@ -475,6 +475,8 @@ extend self
     yaml = ::YAML.load(text)
     if yaml['suffix'] and yaml['records']
       [yaml['suffix'], yaml['records']]
+    elsif yaml['suffix']
+      [yaml['suffix'], {}]
     end
   end
   def trim_lines(yaml)


### PR DESCRIPTION
When updating a completely empty zone, the record list will
be empty (not even a hash - simply nil). The code couldn't handle
that.
