### PR TITLE
use puts instead of write to output the YAML.trim_lines array

### DIFF
--- a/bin/zonify
+++ b/bin/zonify
@@ -189,7 +189,7 @@ def main
     qualified = Zonify::Mappings.rewrite(new_records, [[new_suffix,[suffix]]])
     changes = Zonify.diff(qualified, old_records, (types or %w| * |))
     STDERR.puts(display(changes)) unless quiet
-    STDOUT.write(Zonify::YAML.trim_lines(YAML.dump(changes)))
+    STDOUT.puts(Zonify::YAML.trim_lines(YAML.dump(changes)))
   when 'sync'
     suffix = ARGV[1]
     check_name(suffix)
@@ -214,7 +214,7 @@ def main
     _, old_records = aws.route53_zone(suffix)
     changes = Zonify.diff(mapped, old_records, (types or %w| CNAME SRV |))
     STDERR.puts(display(changes)) unless quiet
-    STDOUT.write(Zonify::YAML.trim_lines(YAML.dump(changes)))
+    STDOUT.puts(Zonify::YAML.trim_lines(YAML.dump(changes)))
   when 'summarize'
     handle = ARGV[1] ? File.open(ARGV[1]) : STDIN
     changes = yaml_with_default(handle, [])


### PR DESCRIPTION
`.write` attempts to output it as a string representation of an array
whereas `.puts` just concatenates the array elements together

the latter is what we need, as each element of the array is a line of YAML

(`trim_lines` outputs an array)

The setup:

```
sarcasm:~/tmp$ zonify r53 testzone.example > testzone.example.yaml
sarcasm:~/tmp$ cat testzone.example.yaml
suffix: .testzone.example.
records:
  testzone.example.:
    NS:
      :ttl: '172800'
      :value:
      - ns-462.awsdns-57.com.
      - ns-1387.awsdns-45.org.
      - ns-536.awsdns-03.net.
      - ns-1779.awsdns-30.co.uk.
    SOA:
      :ttl: '900'
      :value:
      - ns-462.awsdns-57.com. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400
sarcasm:~/tmp$ cat testzone.changed.yaml
suffix: .testzone.example.
records:
  testzone.example.:
    NS:
      :ttl: '172800'
      :value:
      - ns-462.awsdns-57.com.
      - ns-1387.awsdns-45.org.
      - ns-536.awsdns-03.net.
      - ns-1779.awsdns-30.co.uk.
    SOA:
      :ttl: '900'
      :value:
      - ns-462.awsdns-57.com. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400
    A:
      :ttl: '300'
      :value:
      - 127.0.0.1
```

Without this patch, the output of `zonify diff` is:

```
sarcasm:~/tmp$ zonify diff testzone.changed.yaml testzone.example.yaml 2>/dev/null
["- :ttl: '300'\n", "  :value:\n", "  - 127.0.0.1\n", "  :name: testzone.example.\n", "  :type: A\n", "  :action: DELETE\n"]
```

This is not valid YAML, and causes trouble when piped into `zonify apply`:

```
sarcasm:~/tmp$ zonify diff testzone.changed.yaml testzone.example.yaml | zonify apply
There are 1 changes.
testzone.example. A  --->  delete
/Users/sean/.gem/ruby/1.9.1/gems/zonify-0.4.3/bin/zonify:75:in `[]': can't convert Symbol into Integer (TypeError)
    from /Users/sean/.gem/ruby/1.9.1/gems/zonify-0.4.3/bin/zonify:75:in `block in display'
    from /Users/sean/.gem/ruby/1.9.1/gems/zonify-0.4.3/bin/zonify:74:in `each'
    from /Users/sean/.gem/ruby/1.9.1/gems/zonify-0.4.3/bin/zonify:74:in `inject'
    from /Users/sean/.gem/ruby/1.9.1/gems/zonify-0.4.3/bin/zonify:74:in `display'
    from /Users/sean/.gem/ruby/1.9.1/gems/zonify-0.4.3/bin/zonify:226:in `main'
    from /Users/sean/.gem/ruby/1.9.1/gems/zonify-0.4.3/bin/zonify:253:in `<top (required)>'
    from /Users/sean/.gem/ruby/1.9.1/bin/zonify:23:in `load'
    from /Users/sean/.gem/ruby/1.9.1/bin/zonify:23:in `<main>'
```

_With_ this patch, the output of `zonify diff` is well-formed YAML:

```
sarcasm:~/tmp$ zonify diff testzone.changed.yaml testzone.example.yaml 2>/dev/null
- :ttl: '300'
  :value:
  - 127.0.0.1
  :name: testzone.example.
  :type: A
  :action: DELETE
```

This, then, allows the normal `zonify diff … | zonify apply` workflow:

```
sarcasm:~/tmp$ zonify diff testzone.example.yaml testzone.changed.yaml | zonify apply
There are 1 changes.
testzone.example. A  --->  create
There are 1 changes.
testzone.example. A  --->  create
```

Note: I've also applied the same change to `ec2/r53`; it may additionally be required in `eips`. I don't use either of these, though, so I can't effectively test.

Also of note: this worked just fine for me before an OS reinstall. I tried tracking down a change in the way `STDOUT.write` works, but didn't have much luck. My guess is that something changed, somewhere in the YAML parser, in the past couple years.

Occurs on Ruby 2.0 and 1.9.1.
