### PR TITLE
Support HealthCheckId

### DIFF
--- a/bin/zonify
+++ b/bin/zonify
@@ -74,8 +74,13 @@ def display(changes)
     'No changes; nothing to do.'
   else
     summary = changes.inject({}) do |acc, change|
-      name, type, set = [change[:name], change[:type], change[:set_identifier]]
-      key = "#{name} #{type}" + ( set ? " (#{set})" : "" )
+      name, type, set, health_check_id = [change[:name],
+                                          change[:type],
+                                          change[:set_identifier],
+                                          change[:health_check_id]]
+      key = "#{name} #{type}"
+      key += ( set ? " (#{set})" : "" )
+      key += ( health_check_id ? " (#{health_check_id})" : "")
       acc[key] ||= []
       acc[key]  << change[:action]
       acc

--- a/lib/zonify.rb
+++ b/lib/zonify.rb
@@ -239,9 +239,11 @@ end
 def tree(records)
   records.inject({}) do |acc, record|
     name, type, ttl, value,
-    weight, set           = [ record[:name],   record[:type],
+    weight, set,
+    health_check_id       = [ record[:name],   record[:type],
                               record[:ttl],    record[:value],
-                              record[:weight], record[:set_identifier] ]
+                              record[:weight], record[:set_identifier],
+                              record[:health_check_id] ]
     reference = acc[name]       ||= {}
     reference = reference[type] ||= {}
     reference = reference[set]  ||= {} if set
@@ -249,6 +251,7 @@ def tree(records)
     reference[:ttl]               = ttl
     reference[:value]             = appended.sort.uniq
     reference[:weight]            = weight if weight
+    reference[:health_check_id]   = health_check_id if health_check_id
     acc
   end
 end
@@ -340,15 +343,18 @@ end
 def tree_from_right_aws(records)
   records.inject({}) do |acc, record|
     name, type, ttl, value,
-    weight, set           = [ record[:name],   record[:type],
+    weight, set,
+    health_check_id       = [ record[:name],   record[:type],
                               record[:ttl],    record[:value],
-                              record[:weight], record[:set_identifier] ]
+                              record[:weight], record[:set_identifier],
+                              record[:health_check_id] ]
     reference = acc[name]       ||= {}
     reference = reference[type] ||= {}
     reference = reference[set]  ||= {} if set
     reference[:ttl]               = ttl
     reference[:value]             = (value or [])
     reference[:weight]            = weight if weight
+    reference[:health_check_id]   = health_check_id if health_check_id
     acc
   end
 end


### PR DESCRIPTION
## Support HealthCheckId

If an healthcheck is set on the record, `zonify` is unable to modify this resource record cause attributes does not match. This PR is fixing that.

```plain
InvalidChangeBatch => Tried to delete resource record set [name='dns.domain.com', type='CNAME', set-identifier='i-0080b6dec90929484'] but the values provided do not match the current values
```